### PR TITLE
`target_type` is no more

### DIFF
--- a/commonutils.py
+++ b/commonutils.py
@@ -168,7 +168,7 @@ def setup_nrnbbcore_register_mapping(rings):
     return recordlist
 
 def write_report_config(output_file, report_name, target_name, report_type, report_variable,
-                        unit, report_format, target_type, dt, start_time, end_time, gids,
+                        unit, report_format, sections, compartments, dt, start_time, end_time, gids,
                         buffer_size=8, scaling: Literal["none", "area"] = "area"):
     """
     Writes the configuration for a report to a file. Check the docs here:
@@ -189,7 +189,8 @@ def write_report_config(output_file, report_name, target_name, report_type, repo
             report_variable,
             unit,
             report_format,
-            target_type,
+            sections,
+            compartments,
             dt,
             start_time,
             end_time,

--- a/commonutils.py
+++ b/commonutils.py
@@ -182,7 +182,7 @@ def write_report_config(output_file, report_name, target_name, report_type, repo
     with report_conf.open("wb") as fp:
         # Write the formatted string to the file
         fp.write(b"1\n")
-        fp.write(("%s %s %s %s %s %s %d %lf %lf %lf %d %d %s\n" % (
+        fp.write(("%s %s %s %s %s %s %s %s %lf %lf %lf %d %d %s\n" % (
             report_name,
             target_name,
             report_type,

--- a/ringtest.py
+++ b/ringtest.py
@@ -175,7 +175,7 @@ def create_rings():
             sim_conf_file = "sim.conf"
             if settings.rank == 0:
                 write_report_config(report_conf_file, "soma.h5", "Mosaic", "compartment", "v",
-                                    "mV", "SONATA", 2, 1, 0, tstop, list(range(ncell)))
+                                    "mV", "SONATA", "soma", "center", 1, 0, tstop, list(range(ncell)))
                 write_spike_config(report_conf_file, "spikes.h5", ["default"], [0])
                 write_sim_config(sim_conf_file, "corenrn_data", report_conf_file, tstop)
             coreneuron.sim_config=sim_conf_file


### PR DESCRIPTION
target_type was an enum that was built from the combination of section_type and compartments (this was a bool).

Now we have 2 enums that are passed by string in report.conf. This has several benefits:

- inspection: we can understand more easily what we are passing
- de-correlation: we can change one enum without changing the other
- no need of special encoding/decoding: before we needed to pack and unpack the enums into 1
- easier to expand in case more options arise

Drawbacks:

- less performant since we need to encode/decode with strings

I think the drawback are totally ininfluent. Report parsing is not performance critical and clarity and simplicity should rein here